### PR TITLE
Set FSEL=1 in CR reg to select bank 2

### DIFF
--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -148,7 +148,7 @@ impl<'d, T: Instance, Dma> Qspi<'d, T, Dma> {
         d3.set_as_af(d3.af_num(), AFType::OutputPushPull);
         d3.set_speed(crate::gpio::Speed::VeryHigh);
 
-        Self::new_inner(
+        let qspi = Self::new_inner(
             peri,
             Some(d0.map_into()),
             Some(d1.map_into()),
@@ -158,7 +158,13 @@ impl<'d, T: Instance, Dma> Qspi<'d, T, Dma> {
             Some(nss.map_into()),
             dma,
             config,
-        )
+        );
+
+        T::REGS.cr().modify(|w| {
+            w.set_fsel(true);
+        });
+
+        qspi
     }
 
     fn new_inner(


### PR DESCRIPTION
This fixes bank 2 comms for me on STM32F412RE. Need to set FSEL=1 in QUADSPI_CR reg bit #7 to select bank 2. I can now read JETEC ID from my flash memory chip using Bank 2 pins in single line indirect mode.

> 0.327484 INFO  [qspi] JETEC ID: Manuf=0xef MemType=0x40 Capacity=0x18

I can also read & write to the chip's flash in single line mode. I haven't yet tested dual/quad line mode.